### PR TITLE
Use python interpreter from user's PATH

### DIFF
--- a/sketchToDroidRes.py
+++ b/sketchToDroidRes.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 import ConfigParser
 

--- a/sketchToDroidResTest.py
+++ b/sketchToDroidResTest.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 import sketchToDroidRes
 


### PR DESCRIPTION
- Switch sketchToDroidRes.py from using a direct link to python to
  instead use env
- Switch sketchToDroidResTest.py from using a direct link to python to
  instead use env

This is the standard hash bang for python scripts.
